### PR TITLE
Rewrite chat API to enrich live agent context

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,6 +2,10 @@
 import { NextRequest } from "next/server";
 import { AzureOpenAI } from "openai";
 import { retrieveContext } from "@/lib/retriever";
+import SYSTEM_PROMPT from "@/lib/systemPrompt";
+import { db } from "@/lib/db";
+import { promises as fs } from "fs";
+import path from "path";
 
 type Role = "system" | "user" | "assistant";
 type Msg = { role: Role; content: string };
@@ -12,92 +16,127 @@ function need(name: string) {
   return v;
 }
 
-const endpoint   = need("AZURE_OPENAI_ENDPOINT");
-const apiKey     = need("AZURE_OPENAI_API_KEY");
+const endpoint = need("AZURE_OPENAI_ENDPOINT");
+const apiKey = need("AZURE_OPENAI_API_KEY");
 const apiVersion = process.env.AZURE_OPENAI_API_VERSION || "2024-12-01-preview";
-const model      = need("AZURE_OPENAI_DEPLOYMENT"); // chat DEPLOYMENT name
+const model = need("AZURE_OPENAI_DEPLOYMENT"); // chat DEPLOYMENT name
 
 const client = new AzureOpenAI({ endpoint, apiKey, apiVersion });
+
+async function buildPolicySection(): Promise<string | null> {
+  const policy = db.profile.policy;
+  if (!policy) return null;
+
+  const metadataLines = [
+    `File name: ${policy.name}`,
+    policy.mime ? `MIME type: ${policy.mime}` : null,
+    `Size (bytes): ${policy.size}`,
+  ].filter(Boolean);
+
+  if (!policy.storedAt) {
+    return `### Customer Policy Document\n${metadataLines.join("\n")}`;
+  }
+
+  const relPath = policy.storedAt.replace(/^\/+/, "");
+  const absolutePath = path.join(process.cwd(), "public", relPath);
+
+  try {
+    const fileBuffer = await fs.readFile(absolutePath);
+    const text = fileBuffer.toString("utf-8");
+    const sanitized = text.replace(/\u0000/g, "");
+    const printable = sanitized.replace(/[^\x09\x0A\x0D\x20-\x7E]/g, "");
+    const ratio = sanitized.length ? printable.length / sanitized.length : 1;
+    const finalText = ratio < 0.5 ? printable : sanitized;
+    const MAX_CHARS = 8000;
+    const trimmed = finalText.length > MAX_CHARS ? finalText.slice(0, MAX_CHARS) : finalText;
+
+    if (!trimmed.trim()) {
+      return `### Customer Policy Document\n${metadataLines.join("\n")}\n\nThe uploaded policy file is not in a readable text format. Ask the customer for relevant excerpts when needed.`;
+    }
+
+    return `### Customer Policy Document\n${metadataLines.join("\n")}\n\n${trimmed}`;
+  } catch (error) {
+    console.warn("Unable to load policy document", error);
+    return `### Customer Policy Document\n${metadataLines.join("\n")}\n\nThe policy could not be loaded from disk. Ask the customer to re-upload if context is required.`;
+  }
+}
 
 export async function POST(req: NextRequest) {
   try {
     const body = (await req.json()) as {
       messages: Msg[];
       useRag?: boolean;
-      maxTokens?: number;      // optional override
+      systemPrompt?: string;
+      instructions?: string;
     };
 
+    if (!Array.isArray(body.messages)) {
+      return new Response(JSON.stringify({ error: "Invalid payload" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const userFacingPrompt = body.systemPrompt?.trim() || SYSTEM_PROMPT.trim();
+    const extraInstructions = body.instructions?.trim();
+
+    const sections: string[] = [userFacingPrompt];
+
+    if (extraInstructions) {
+      sections.push(`### Additional Instructions\n${extraInstructions}`);
+    }
+
     const useRag = body.useRag !== false;
-    const max_completion_tokens = Math.max(
-      1,
-      Math.min(Number(body?.maxTokens ?? 4096), 16384)
-    );
-
-    let sys = `You are an AI insurance advisor that helps consumers choose appropriate personal home and auto coverage and navigate claims.`;
-
-    // Append KB context (RAG)
     const lastUser = [...body.messages].reverse().find((m) => m.role === "user");
     if (useRag && lastUser?.content) {
       const { context } = await retrieveContext(lastUser.content, 6);
       if (context) {
-        const trimmed = context.length > 6000 ? context.slice(0, 6000) : context;
-        sys += `
-
-### Knowledge Base Context (verbatim; cite with bracket numbers):
-${trimmed}
-`;
+        sections.push(
+          `### Knowledge Base Context (verbatim; cite with bracket numbers)\n${context}`
+        );
       }
     }
 
-    const messages: Msg[] = [{ role: "system", content: sys }, ...body.messages];
+    const policySection = await buildPolicySection();
+    if (policySection) {
+      sections.push(policySection);
+    }
 
-    // Start a streaming completion (returns AsyncIterable<ChatCompletionChunk>)
+    const messages: Msg[] = [{ role: "system", content: sections.join("\n\n---\n\n") }, ...body.messages];
+
     const completion = await client.chat.completions.create({
       model,
       messages,
       stream: true,
-      // Some Azure regions/models only accept the default temperature (1).
-      // If your deployment rejects custom values, remove this line.
-      temperature: 1,
-      max_completion_tokens,
+      temperature: 0.7,
     });
 
-    const enc = new TextEncoder();
+    const encoder = new TextEncoder();
 
     const stream = new ReadableStream<Uint8Array>({
       async start(controller) {
         try {
           for await (const chunk of completion) {
-            // Each chunk is ChatCompletionChunk
             const choice = chunk.choices?.[0];
             if (!choice) continue;
 
             const delta = choice.delta?.content;
-            if (typeof delta === "string" && delta.length) {
-              // Send as NDJSON line: {"content":"..."}
-              controller.enqueue(enc.encode(JSON.stringify({ content: delta }) + "\n"));
-            }
-
-            // Optional: let the client know if we hit the length stop reason
-            if (choice.finish_reason === "length") {
-              controller.enqueue(
-                enc.encode(JSON.stringify({ note: "truncated" }) + "\n")
-              );
+            if (typeof delta === "string" && delta.length > 0) {
+              controller.enqueue(encoder.encode(delta));
             }
           }
         } catch (err) {
-          controller.enqueue(
-            enc.encode(JSON.stringify({ error: String(err) }) + "\n")
-          );
-        } finally {
-          controller.close();
+          controller.error(err);
+          return;
         }
+
+        controller.close();
       },
     });
 
     return new Response(stream, {
       headers: {
-        "Content-Type": "application/json; charset=utf-8",
+        "Content-Type": "text/plain; charset=utf-8",
         "Cache-Control": "no-store",
       },
     });


### PR DESCRIPTION
## Summary
- rebuild the chat route to assemble the master system prompt, optional user instructions, Pinecone knowledge base context, and the uploaded policy before calling Azure OpenAI
- stream assistant responses as plain text without imposing completion token limits for a smoother chat experience
- surface policy metadata when the document cannot be read and harden request validation and streaming error handling

## Testing
- ⚠️ `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_b_68e566e3ae508328b68baa9b6c03e0a1