### PR TITLE
Add policy upload controls to chat experience

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import Chat from "@/components/Chat";
+import { db } from "@/lib/db";
 import Button from "@/components/ui/Button";
 import Link from "next/link";
 
@@ -49,7 +50,7 @@ export default function ChatPage() {
         className="relative mx-auto mt-8 flex w-full max-w-5xl flex-1 flex-col rounded-3xl border border-[var(--color-muted)] bg-white shadow-sm md:mt-12"
         style={{ minHeight: "80vh" }}
       >
-        <Chat />
+        <Chat initialPolicy={db.profile.policy ?? null} />
       </motion.section>
     </div>
   );

--- a/components/FileDropzone.tsx
+++ b/components/FileDropzone.tsx
@@ -4,11 +4,13 @@ import type { PolicyFile } from "@/lib/types";
 
 type Props = {
   onUploaded: (policy: PolicyFile) => void;
+  title?: string;
+  description?: string;
 };
 
 type UploadResponse = { ok: true; policy: PolicyFile } | { ok?: false; error: string };
 
-export default function FileDropzone({ onUploaded }: Props) {
+export default function FileDropzone({ onUploaded, title, description }: Props) {
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -45,8 +47,10 @@ export default function FileDropzone({ onUploaded }: Props) {
     >
       <div className="flex items-center justify-between gap-2">
         <div>
-          <div className="font-medium">Upload your policy</div>
-          <div className="text-[var(--color-ink-2)]">Drag & drop or choose a file (PDF, DOCX, images)</div>
+          <div className="font-medium">{title ?? "Upload your policy"}</div>
+          <div className="text-[var(--color-ink-2)]">
+            {description ?? "Drag & drop or choose a file (PDF, DOCX, images)"}
+          </div>
         </div>
 
         <label className="cursor-pointer rounded-xl bg-[var(--color-primary)] px-3 py-2 text-sm text-white shadow-sm transition hover:opacity-90 focus-within:outline-none focus-within:ring-2 focus-within:ring-[var(--color-primary)]/35">


### PR DESCRIPTION
## Summary
- expose the stored profile policy to the chat screen so it can be displayed alongside the conversation
- add a reusable file dropzone with configurable copy and show upload success feedback
- refresh the chat UI to allow uploading or replacing a policy file directly from the conversation

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5796cb53483289d692ced26532cf5