### PR TITLE
Remove unsupported temperature parameter from Azure chat requests

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -139,7 +139,6 @@ export async function POST(req: NextRequest) {
       model: azure.deployment,
       messages,
       stream: true,
-      temperature: 0.7,
     });
 
     const encoder = new TextEncoder();


### PR DESCRIPTION
## Summary
- remove the explicit temperature override when creating Azure chat completions so the default supported value is used

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e57e47b39c832890be5dc441bba5c5